### PR TITLE
Fix user name with spaces not working

### DIFF
--- a/bitbucket/resource_user.go
+++ b/bitbucket/resource_user.go
@@ -152,7 +152,7 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 
 	client := m.(*BitbucketServerProvider).BitbucketClient
 	req, err := client.Get(fmt.Sprintf("/rest/api/1.0/users/%s",
-		url.QueryEscape(name),
+		url.PathEscape(name),
 	))
 
 	if err != nil {
@@ -192,7 +192,7 @@ func resourceUserExists(d *schema.ResourceData, m interface{}) (bool, error) {
 
 	client := m.(*BitbucketServerProvider).BitbucketClient
 	req, err := client.Get(fmt.Sprintf("/rest/api/1.0/users/%s",
-		url.QueryEscape(name),
+		url.PathEscape(name),
 	))
 
 	if err != nil {

--- a/bitbucket/resource_user_test.go
+++ b/bitbucket/resource_user_test.go
@@ -15,7 +15,7 @@ func TestAccBitbucketUser(t *testing.T) {
 	userRand := fmt.Sprintf("%v", rand.New(rand.NewSource(time.Now().UnixNano())).Int())
 	config := fmt.Sprintf(`
 		resource "bitbucketserver_user" "test" {
-			name = "admin%v"
+			name = "admin %v"
 			display_name = "Admin %v"
 			email_address = "admin%v@example.com"
 		}
@@ -31,7 +31,7 @@ func TestAccBitbucketUser(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("bitbucketserver_user.test", "name", "admin"+userRand),
+					resource.TestCheckResourceAttr("bitbucketserver_user.test", "name", "admin "+userRand),
 					resource.TestCheckResourceAttr("bitbucketserver_user.test", "display_name", "Admin "+userRand),
 					resource.TestCheckResourceAttr("bitbucketserver_user.test", "email_address", "admin"+userRand+"@example.com"),
 					resource.TestCheckResourceAttrSet("bitbucketserver_user.test", "initial_password"),
@@ -40,7 +40,7 @@ func TestAccBitbucketUser(t *testing.T) {
 			{
 				Config: configModified,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("bitbucketserver_user.test", "name", "admin"+userRand),
+					resource.TestCheckResourceAttr("bitbucketserver_user.test", "name", "admin "+userRand),
 					resource.TestCheckResourceAttr("bitbucketserver_user.test", "display_name", "Admin Updated "+userRand),
 					resource.TestCheckResourceAttr("bitbucketserver_user.test", "email_address", "admin"+userRand+"@example.com"),
 					resource.TestCheckResourceAttrSet("bitbucketserver_user.test", "initial_password"),


### PR DESCRIPTION
This PR fixes #9 which makes it impossible to create user with space in his username. This is perfectly valid when creating user via UI 