### PR TITLE
Implement data source bitbucketserver_user

### DIFF
--- a/bitbucket/data_user.go
+++ b/bitbucket/data_user.go
@@ -1,0 +1,35 @@
+package bitbucket
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"email_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
+	d.SetId(d.Get("name").(string))
+	return resourceUserRead(d, m)
+}

--- a/bitbucket/data_user_test.go
+++ b/bitbucket/data_user_test.go
@@ -1,0 +1,31 @@
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccBitbucketDataUser(t *testing.T) {
+	config := `
+		data "bitbucketserver_user" "test" {
+			name = "admin"
+		}
+	`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.bitbucketserver_user.test", "name", "admin"),
+					resource.TestCheckResourceAttr("data.bitbucketserver_user.test", "email_address", "admin@example.com"),
+					resource.TestCheckResourceAttr("data.bitbucketserver_user.test", "display_name", "Admin"),
+					resource.TestCheckResourceAttr("data.bitbucketserver_user.test", "user_id", "1"),
+				),
+			},
+		},
+	})
+}

--- a/bitbucket/provider.go
+++ b/bitbucket/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 			"bitbucketserver_repository_hooks":              dataSourceRepositoryHooks(),
 			"bitbucketserver_repository_permissions_groups": dataSourceRepositoryPermissionsGroups(),
 			"bitbucketserver_repository_permissions_users":  dataSourceRepositoryPermissionsUsers(),
+			"bitbucketserver_user":                          dataSourceUser(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"bitbucketserver_banner":                       resourceBanner(),

--- a/bitbucket/resource_user.go
+++ b/bitbucket/resource_user.go
@@ -4,18 +4,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 type User struct {
 	Name         string `json:"name,omitempty"`
 	EmailAddress string `json:"emailAddress,omitempty"`
 	DisplayName  string `json:"displayName,omitempty"`
+	UserId       int    `json:"id,omitempty"`
 }
 
 type UserUpdate struct {
@@ -176,6 +178,7 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("name", user.Name)
 		d.Set("email_address", user.EmailAddress)
 		d.Set("display_name", user.DisplayName)
+		d.Set("user_id", user.UserId)
 	}
 
 	return nil

--- a/docusaurus/docs/data_user.md
+++ b/docusaurus/docs/data_user.md
@@ -1,0 +1,24 @@
+---
+id: data_bitbucketserver_user
+title: bitbucketserver_user
+---
+
+This data source allows you to retrieve Bitbucket user details.
+
+## Example Usage
+
+```hcl
+data "bitbucketserver_user" "admin" {
+  name = "admin"
+}
+```
+
+## Argument Reference
+
+* `name` - Unique name of the user.
+
+## Attribute Reference
+
+* `email_address` - User's email.
+* `display_name` - User's display name.
+* `user_id` - User's ID.

--- a/docusaurus/docs/resource_user.md
+++ b/docusaurus/docs/resource_user.md
@@ -25,6 +25,7 @@ resource "bitbucketserver_user" "admin" {
 ## Attribute Reference
 
 * `initial_password` - The generated user password. Only available if password was handled on Terraform resource creation, not import.
+* `user_id` - The user ID.
 
 ## Import
 

--- a/docusaurus/website/i18n/en.json
+++ b/docusaurus/website/i18n/en.json
@@ -43,6 +43,9 @@
       "data_bitbucketserver_repository_permissions_users": {
         "title": "bitbucketserver_repository_permissions_users"
       },
+      "data_bitbucketserver_user": {
+        "title": "bitbucketserver_user"
+      },
       "provider": {
         "title": "Getting Started"
       },

--- a/docusaurus/website/sidebars.json
+++ b/docusaurus/website/sidebars.json
@@ -16,7 +16,8 @@
       "data_bitbucketserver_project_permissions_users",
       "data_bitbucketserver_repository_hooks",
       "data_bitbucketserver_repository_permissions_groups",
-      "data_bitbucketserver_repository_permissions_users"
+      "data_bitbucketserver_repository_permissions_users",
+      "data_bitbucketserver_user"
     ],
     "Resources": [
       "bitbucketserver_banner",


### PR DESCRIPTION
This PR adds the data source for user to be able to read his user ID, email, display name based on his username. This datasource can be easily extended in the future to provide more attributes.