### PR TITLE
removed omitempty from the forkable boolean value

### DIFF
--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -19,7 +19,7 @@ type Repository struct {
 	Name        string `json:"name,omitempty"`
 	Slug        string `json:"slug,omitempty"`
 	Description string `json:"description,omitempty"`
-	Forkable    bool   `json:"forkable,omitempty"`
+	Forkable    bool   `json:"forkable"`
 	Public      bool   `json:"public,omitempty"`
 	Links       struct {
 		Clone []CloneUrl `json:"clone,omitempty"`

--- a/bitbucket/resource_repository_test.go
+++ b/bitbucket/resource_repository_test.go
@@ -24,10 +24,19 @@ func TestAccBitbucketRepository_basic(t *testing.T) {
 			project = bitbucketserver_project.test.key
 			name = "test-repo-for-repository-test"
 			description = "My Repo"
+			forkable = false
+			public = false
+		}
+
+		resource "bitbucketserver_repository" "test_repo_defaults" {
+			project = bitbucketserver_project.test.key
+			name = "test-repo-for-repository-test_defaults"
+			description = "My_Repo2"
 		}
 	`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
 
 	configModified := strings.ReplaceAll(config, "My Repo", "My Updated Repo")
+	configModifiedBool := strings.ReplaceAll(config, "false", "true")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -41,6 +50,10 @@ func TestAccBitbucketRepository_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "slug", "test-repo-for-repository-test"),
 					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "name", "test-repo-for-repository-test"),
 					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "description", "My Repo"),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "forkable", "false"),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "public", "false"),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo_defaults", "forkable", "true"),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo_defaults", "public", "false"),
 				),
 			},
 			{
@@ -50,6 +63,16 @@ func TestAccBitbucketRepository_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "slug", "test-repo-for-repository-test"),
 					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "name", "test-repo-for-repository-test"),
 					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "description", "My Updated Repo"),
+				),
+			},
+			{
+				Config: configModifiedBool,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBitbucketRepositoryExists("bitbucketserver_repository.test_repo", &repo),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "slug", "test-repo-for-repository-test"),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "name", "test-repo-for-repository-test"),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "forkable", "true"),
+					resource.TestCheckResourceAttr("bitbucketserver_repository.test_repo", "public", "true"),
 				),
 			},
 		},


### PR DESCRIPTION
Since `forkable` has a default value of `true`, when `false` is supplied, the `omitempty` json tag treats the `false` value as an empty value.  This causes the json marshaling to omit the the `false`/empty value, thus using the default bitbucket behavior of setting the value to 'true'.

*note - the `public` and `enable_git_lfs` booleans are unaffected due to them having a `false` default value. (`enable_git_lfs` does not even appear to be fully implemented, it is not part of the repo struct and the test does not assert the value)