### PR TITLE
fix: Allow unmarshal json to tolerate null datetimes

### DIFF
--- a/bitbucket/json_types.go
+++ b/bitbucket/json_types.go
@@ -15,6 +15,11 @@ func (t jsonTime) MarshalJSON() ([]byte, error) {
 func (t *jsonTime) UnmarshalJSON(s []byte) (err error) {
 	r := strings.Replace(string(s), `"`, ``, -1)
 
+	if r == "null" {
+		*(*time.Time)(t) = time.Time{}
+		return
+	}
+
 	q, err := strconv.ParseInt(r, 10, 64)
 	if err != nil {
 		return err


### PR DESCRIPTION
When we tried using bitbucketserver_license for one of our license keys, we discovered that while the license was applied successfully onto the server, the response json had several attributes set to null. In the body of the response, gracePeriodEndDate and expiryDate were both null.

We've added code to handle this case. Since we were not sure what to parse null time to, we just returned the zero value.