### PR TITLE
Fix an issue where manual user removing requires terraform state rm.

### DIFF
--- a/bitbucket/resource_group.go
+++ b/bitbucket/resource_group.go
@@ -3,6 +3,7 @@ package bitbucket
 import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
+	"log"
 	"net/url"
 )
 
@@ -74,7 +75,9 @@ func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	return fmt.Errorf("unable to find a matching group %s", groupName)
+	d.SetId("")
+	log.Printf("[WARN] Group %s not found, removing from state", groupName)
+	return nil
 }
 
 func resourceGroupUpdate(d *schema.ResourceData, m interface{}) error {

--- a/bitbucket/resource_user_group.go
+++ b/bitbucket/resource_user_group.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
+	"log"
 	"strings"
 )
 
@@ -103,7 +104,9 @@ func resourceUserGroupRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	return fmt.Errorf("unable to find a matching user %s in group %s", userGroup.User, userGroup.Group)
+	d.SetId("")
+	log.Printf("[WARN] User %s in group %s not found, removing from state", userGroup.User, userGroup.Group)
+	return nil
 }
 
 func resourceUserGroupDelete(d *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
When somebody manually removes a user plan and apply will fail unless terraform state rm is used. This should remove the resource from state that has already been manually removed.