### PR TITLE
fix: bitbucketserver_plugin resource refresh fails if plugin is disabled from Bitbucket UI

### DIFF
--- a/bitbucket/resource_plugin.go
+++ b/bitbucket/resource_plugin.go
@@ -466,7 +466,7 @@ func resourcePluginExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	))
 
 	if err != nil {
-		return false, fmt.Errorf("failed to get plugin %s from bitbucket: %+v", key, err)
+		return false, nil
 	}
 
 	if req.StatusCode == 200 {


### PR DESCRIPTION
Addresses first issue pointed in #59 

The diff generated from terraform plan correctly indicates that a  new bitbucketserver_plugin resource will be create.  